### PR TITLE
fix: check does not run the zotsample executable

### DIFF
--- a/check
+++ b/check
@@ -1,6 +1,6 @@
 #!/bin/sh
 #set -x
-if ! [ ./zotsample ]; then
+if ! ./src/zotsample; then
 	echo "zot sample does not work" >&2
   exit 1
 else


### PR DESCRIPTION
The current check script does not run actually run the zotsample executable.
It returns "All tests passed" even if the build failed and no executable was produced.